### PR TITLE
Utilize conllu python library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ allennlp==0.9.0
 tensorflow
 pandas
 jupyter
+conllu

--- a/train.py
+++ b/train.py
@@ -54,7 +54,7 @@ if not args.name == "multilingual":
         for line in f.readlines():
             if line.isspace():
                 sentence_count += 1
-                num_warmup_steps = round(sentence_count / args.batch_size)
+        num_warmup_steps = round(sentence_count / args.batch_size)
 
 configs = []
 

--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@ import copy
 import datetime
 import logging
 import argparse
+import glob
 
 from allennlp.common import Params
 from allennlp.common.util import import_submodules
@@ -22,6 +23,8 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--name", default="", type=str, help="Log dir name")
 parser.add_argument("--base_config", default="config/udify_base.json", type=str, help="Base configuration file")
 parser.add_argument("--config", default=[], type=str, nargs="+", help="Overriding configuration files")
+parser.add_argument("--dataset_dir", default="data/ud-treebanks-v2.5", type=str, help="The path containing all UD treebanks")
+parser.add_argument("--batch_size", default=32, type=int, help="The batch size used by the model; the number of training sentences is divided by this number.")
 parser.add_argument("--device", default=None, type=int, help="CUDA device; set to -1 for CPU")
 parser.add_argument("--resume", type=str, help="Resume training with the given model")
 parser.add_argument("--lazy", default=None, action="store_true", help="Lazy load the dataset")
@@ -36,6 +39,22 @@ log_dir_name = args.name
 if not log_dir_name:
     file_name = args.config[0] if args.config else args.base_config
     log_dir_name = os.path.basename(file_name).split(".")[0]
+
+if not args.name == "multilingual":
+    train_file = args.name + "-ud-train.conllu"
+    pathname = os.path.join(args.dataset_dir, "*", train_file)
+    train_path = glob.glob(pathname).pop()
+    treebank_path = os.path.dirname(train_path)
+
+    if train_path:
+        logger.info(f"found training file: {train_path}, calculating the warmup and start steps")
+    
+        f = open(train_path, 'r', encoding="utf-8")
+        sentence_count = 0
+        for line in f.readlines():
+            if line.isspace():
+                sentence_count += 1
+                num_warmup_steps = round(sentence_count / args.batch_size)
 
 configs = []
 
@@ -56,6 +75,25 @@ else:
     configs.append(Params.from_file(os.path.join(serialization_dir, "config.json")))
 
 train_params = util.merge_configs(configs)
+
+if not args.name == "multilingual":
+    # overwrite the default params with the language-specific ones
+    for param in train_params:
+        if param == "train_data_path":
+            train_params["train_data_path"] = os.path.join(treebank_path, f"{args.name}-ud-train.conllu")
+        if param == "validation_data_path":
+            train_params["validation_data_path"] = os.path.join(treebank_path, f"{args.name}-ud-dev.conllu")
+        if param == "test_data_path":
+            train_params["test_data_path"] = os.path.join(treebank_path, f"{args.name}-ud-test.conllu")
+        
+        if param == "trainer":
+            for sub_param in train_params["trainer"]:
+                if sub_param == "learning_rate_scheduler":
+                    train_params["trainer"]["learning_rate_scheduler"]["warmup_steps"] = num_warmup_steps
+                    train_params["trainer"]["learning_rate_scheduler"]["start_step"] = num_warmup_steps
+                    
+                    logger.info(f"changing warmup and start steps for {train_path} to {num_warmup_steps}")
+                
 if "vocabulary" in train_params:
     # Remove this key to make AllenNLP happy
     train_params["vocabulary"].pop("non_padded_namespaces", None)

--- a/train.py
+++ b/train.py
@@ -86,6 +86,9 @@ if not args.name == "multilingual":
         if param == "test_data_path":
             train_params["test_data_path"] = os.path.join(treebank_path, f"{args.name}-ud-test.conllu")
         
+        if param == "vocabulary":
+            train_params["vocabulary"]["directory_path"] = f"data/vocab/{args.name}/vocabulary"
+        
         if param == "trainer":
             for sub_param in train_params["trainer"]:
                 if sub_param == "learning_rate_scheduler":

--- a/udify/dataset_readers/parser.py
+++ b/udify/dataset_readers/parser.py
@@ -17,22 +17,28 @@ class ParseException(Exception):
     pass
 
 
-def process_MWTs(annotation):
-    """Processes the CoNLLU annotations for multi-word tokens"""
+def process_multiword_tokens(annotation):
+    """
+    Processes CoNLLU annotations for multi-word tokens.
+    If the token id returned by the conllu library is a tuple object (either a multi-word token or an elided token),
+    then the token id is set to None so that the token won't be used later on by the model.
+    """
     
     for i in range(len(annotation)):
         conllu_id = annotation[i]["id"]
-        # conllu library returns a tuple object for MWTs and elided tokens
         if type(conllu_id) == tuple:
             if "-" in conllu_id:
-                conllu_id = list(conllu_id)
-                conllu_id = str(conllu_id[0]) + '-' + str(conllu_id[-1])
+                conllu_id = str(conllu_id[0]) + "-" + str(conllu_id[2])
                 annotation[i]["multi_id"] = conllu_id
                 annotation[i]["id"] = None
+            elif "." in conllu_id:
+                annotation[i]["id"] = None
+                annotation[i]["multi_id"] = None
         else:
             annotation[i]["multi_id"] = None
     
     return annotation
+
 
 def parse_token_and_metadata(data, fields=None):
     if not data:

--- a/udify/dataset_readers/parser.py
+++ b/udify/dataset_readers/parser.py
@@ -17,6 +17,23 @@ class ParseException(Exception):
     pass
 
 
+def process_MWTs(annotation):
+    """Processes the CoNLLU annotations for multi-word tokens"""
+    
+    for i in range(len(annotation)):
+        conllu_id = annotation[i]["id"]
+        # conllu library returns a tuple object for MWTs and elided tokens
+        if type(conllu_id) == tuple:
+            if "-" in conllu_id:
+                conllu_id = list(conllu_id)
+                conllu_id = str(conllu_id[0]) + '-' + str(conllu_id[-1])
+                annotation[i]["multi_id"] = conllu_id
+                annotation[i]["id"] = None
+        else:
+            annotation[i]["multi_id"] = None
+    
+    return annotation
+
 def parse_token_and_metadata(data, fields=None):
     if not data:
         raise ParseException("Can't create TokenList, no data sent to constructor.")

--- a/udify/dataset_readers/sigmorphon_2019_task_2.py
+++ b/udify/dataset_readers/sigmorphon_2019_task_2.py
@@ -1,7 +1,8 @@
 from typing import Dict, Tuple, List, Any, Callable
 
 from overrides import overrides
-from udify.dataset_readers.parser import parse_line, DEFAULT_FIELDS
+from udify.dataset_readers.parser import parse_line, DEFAULT_FIELDS, process_MWTs
+from conllu import parse_incr
 
 import re
 
@@ -62,15 +63,6 @@ unimorph_schema = {
 }
 
 
-def lazy_parse(text: str, fields: Tuple[str, ...]=DEFAULT_FIELDS):
-    for sentence in text.split("\n\n"):
-        if sentence:
-            # TODO: upgrade conllu library
-            yield [parse_line(line, fields, parse_feats=False)
-                   for line in sentence.split("\n")
-                   if line and not line.strip().startswith("#")]
-
-
 @DatasetReader.register("udify_sigmorphon_2019_task_2")
 class Sigmorphon2019Task2DatasetReader(DatasetReader):
     def __init__(self,
@@ -92,12 +84,14 @@ class Sigmorphon2019Task2DatasetReader(DatasetReader):
         with open(file_path, 'r') as conllu_file:
             logger.info("Reading UD instances from conllu dataset at: %s", file_path)
 
-            for annotation in lazy_parse(conllu_file.read()):
+            for annotation in parse_incr(conllu_file):
                 # CoNLLU annotations sometimes add back in words that have been elided
                 # in the original sentence; we remove these, as we're just predicting
                 # dependencies for the original sentence.
                 # We filter by None here as elided words have a non-integer word id,
                 # and are replaced with None by the conllu python library.
+                
+                annotation = process_MWTs(annotation)
                 multiword_tokens = [x for x in annotation if x["multi_id"] is not None]
                 annotation = [x for x in annotation if x["id"] is not None]
 

--- a/udify/dataset_readers/sigmorphon_2019_task_2.py
+++ b/udify/dataset_readers/sigmorphon_2019_task_2.py
@@ -1,7 +1,7 @@
 from typing import Dict, Tuple, List, Any, Callable
 
 from overrides import overrides
-from udify.dataset_readers.parser import parse_line, DEFAULT_FIELDS, process_MWTs
+from udify.dataset_readers.parser import parse_line, DEFAULT_FIELDS, process_multiword_tokens
 from conllu import parse_incr
 
 import re
@@ -89,10 +89,9 @@ class Sigmorphon2019Task2DatasetReader(DatasetReader):
                 # in the original sentence; we remove these, as we're just predicting
                 # dependencies for the original sentence.
                 # We filter by None here as elided words have a non-integer word id,
-                # and are replaced with None by the conllu python library.
-                
-                annotation = process_MWTs(annotation)
-                multiword_tokens = [x for x in annotation if x["multi_id"] is not None]
+                # and we replace these word ids with None in process_multiword_tokens.                
+                annotation = process_multiword_tokens(annotation)               
+                multiword_tokens = [x for x in annotation if x["multi_id"] is not None]     
                 annotation = [x for x in annotation if x["id"] is not None]
 
                 if len(annotation) == 0:

--- a/udify/dataset_readers/universal_dependencies.py
+++ b/udify/dataset_readers/universal_dependencies.py
@@ -5,7 +5,7 @@ A Dataset Reader for Universal Dependencies, with support for multiword tokens a
 from typing import Dict, Tuple, List, Any, Callable
 
 from overrides import overrides
-from udify.dataset_readers.parser import parse_line, DEFAULT_FIELDS, process_MWTs
+from udify.dataset_readers.parser import parse_line, DEFAULT_FIELDS, process_multiword_tokens
 from conllu import parse_incr
 
 from allennlp.common.file_utils import cached_path
@@ -44,11 +44,9 @@ class UniversalDependenciesDatasetReader(DatasetReader):
                 # in the original sentence; we remove these, as we're just predicting
                 # dependencies for the original sentence.
                 # We filter by None here as elided words have a non-integer word id,
-                # and are replaced with None by the conllu python library.
-                
-                annotation = process_MWTs(annotation)
-                
-                multiword_tokens = [x for x in annotation if x["multi_id"] is not None]         
+                # and we replace these word ids with None in process_multiword_tokens.
+                annotation = process_multiword_tokens(annotation)               
+                multiword_tokens = [x for x in annotation if x["multi_id"] is not None]     
                 annotation = [x for x in annotation if x["id"] is not None]
 
                 if len(annotation) == 0:
@@ -61,9 +59,7 @@ class UniversalDependenciesDatasetReader(DatasetReader):
                 # Extract multiword token rows (not used for prediction, purely for evaluation)
                 ids = [x["id"] for x in annotation]
                 multiword_ids = [x["multi_id"] for x in multiword_tokens]
-                print("multiword_ids", multiword_ids)
                 multiword_forms = [x["form"] for x in multiword_tokens]
-                print("multiword_forms", multiword_forms)
 
                 words = get_field("form")
                 lemmas = get_field("lemma")
@@ -126,6 +122,7 @@ class UniversalDependenciesDatasetReader(DatasetReader):
             "multiword_forms": multiword_forms
         })
 
+        print(fields)
         return Instance(fields)
 
 

--- a/udify/dataset_readers/universal_dependencies.py
+++ b/udify/dataset_readers/universal_dependencies.py
@@ -5,7 +5,8 @@ A Dataset Reader for Universal Dependencies, with support for multiword tokens a
 from typing import Dict, Tuple, List, Any, Callable
 
 from overrides import overrides
-from udify.dataset_readers.parser import parse_line, DEFAULT_FIELDS
+from udify.dataset_readers.parser import parse_line, DEFAULT_FIELDS, process_MWTs
+from conllu import parse_incr
 
 from allennlp.common.file_utils import cached_path
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
@@ -20,15 +21,6 @@ from udify.dataset_readers.lemma_edit import gen_lemma_rule
 import logging
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
-
-
-def lazy_parse(text: str, fields: Tuple[str, ...]=DEFAULT_FIELDS):
-    for sentence in text.split("\n\n"):
-        if sentence:
-            # TODO: upgrade conllu library
-            yield [parse_line(line, fields)
-                   for line in sentence.split("\n")
-                   if line and not line.strip().startswith("#")]
 
 
 @DatasetReader.register("udify_universal_dependencies")
@@ -47,13 +39,16 @@ class UniversalDependenciesDatasetReader(DatasetReader):
         with open(file_path, 'r') as conllu_file:
             logger.info("Reading UD instances from conllu dataset at: %s", file_path)
 
-            for annotation in lazy_parse(conllu_file.read()):
+            for annotation in parse_incr(conllu_file):
                 # CoNLLU annotations sometimes add back in words that have been elided
                 # in the original sentence; we remove these, as we're just predicting
                 # dependencies for the original sentence.
                 # We filter by None here as elided words have a non-integer word id,
                 # and are replaced with None by the conllu python library.
-                multiword_tokens = [x for x in annotation if x["multi_id"] is not None]
+                
+                annotation = process_MWTs(annotation)
+                
+                multiword_tokens = [x for x in annotation if x["multi_id"] is not None]         
                 annotation = [x for x in annotation if x["id"] is not None]
 
                 if len(annotation) == 0:
@@ -66,7 +61,9 @@ class UniversalDependenciesDatasetReader(DatasetReader):
                 # Extract multiword token rows (not used for prediction, purely for evaluation)
                 ids = [x["id"] for x in annotation]
                 multiword_ids = [x["multi_id"] for x in multiword_tokens]
+                print("multiword_ids", multiword_ids)
                 multiword_forms = [x["form"] for x in multiword_tokens]
+                print("multiword_forms", multiword_forms)
 
                 words = get_field("form")
                 lemmas = get_field("lemma")

--- a/udify/dataset_readers/universal_dependencies.py
+++ b/udify/dataset_readers/universal_dependencies.py
@@ -122,7 +122,6 @@ class UniversalDependenciesDatasetReader(DatasetReader):
             "multiword_forms": multiword_forms
         })
 
-        print(fields)
         return Instance(fields)
 
 


### PR DESCRIPTION
This PR addresses #12  and uses the upstream [conllu library](https://github.com/EmilStenstrom/conllu) to retrieve conllu annotations.
In a post-processing step, the token ids of multi-word tokens and elided tokens are set to None so that these annotations won't be used for prediction. The multiword token forms and multiword token ids are stored as normal so that behaviour is the same in the predictor.